### PR TITLE
🐛 - Support non-coroutine handler properly

### DIFF
--- a/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
+++ b/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
@@ -74,17 +74,17 @@ def create_aio_server_interceptor(pin):
 
 
 def _handle_server_exception(
-    server_context,  # type: Union[None, grpc.ServicerContext]
+    servicer_context,  # type: Union[None, grpc.ServicerContext]
     span,  # type: Span
 ):
     # type: (...) -> None
     span.error = 1
-    if server_context is None:
+    if servicer_context is None:
         return
-    if hasattr(server_context, "details"):
-        span._set_str_tag(ERROR_MSG, to_unicode(server_context.details()))
-    if hasattr(server_context, "code") and server_context.code() != 0 and server_context.code() in _STATUS_MAP:
-        span._set_str_tag(ERROR_TYPE, to_unicode(_STATUS_MAP[server_context.code()]))
+    if hasattr(servicer_context, "details"):
+        span._set_str_tag(ERROR_MSG, to_unicode(servicer_context.details()))
+    if hasattr(servicer_context, "code") and servicer_context.code() != 0 and servicer_context.code() in _STATUS_MAP:
+        span._set_str_tag(ERROR_TYPE, to_unicode(_STATUS_MAP[servicer_context.code()]))
 
 
 async def _wrap_aio_stream_response(

--- a/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
+++ b/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
@@ -93,7 +93,7 @@ async def _wrap_aio_stream_response(
     servicer_context,  # type: aio.ServicerContext
     span,  # type: Span
 ):
-    # type: (...) -> RequestIterableType
+    # type: (...) -> ResponseIterableType
     try:
         call = behavior(request_or_iterator, servicer_context)
         async for response in call:
@@ -220,6 +220,7 @@ class _TracedAioRpcMethodHandler(wrapt.ObjectProxy):
 
 class _TracedRpcMethodHandler(wrapt.ObjectProxy):
     def __init__(self, pin, handler_call_details, wrapped):
+        # type: (Pin, grpc.HandlerCallDetails, grpc.RpcMethodHandler) -> None
         super(_TracedRpcMethodHandler, self).__init__(wrapped)
         self._pin = pin
         self._handler_call_details = handler_call_details

--- a/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
+++ b/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
@@ -31,7 +31,10 @@ from ..grpc.utils import set_grpc_method_meta
 Continuation = Callable[[grpc.HandlerCallDetails], Awaitable[grpc.RpcMethodHandler]]
 
 
-_STATUS_MAP = {s.value[0]: s for s in grpc.StatusCode}
+try:
+    _STATUS_MAP = {s.value[0]: s for s in grpc.StatusCode}
+except KeyError:
+    _STATUS_MAP = dict()
 
 
 def _is_coroutine_rpc_method_handler(handler):

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -298,7 +298,7 @@ async def test_pin_not_activated(servicer, tracer):
     "servicer",
     [_SyncHelloServicer, _HelloServicer],
 )
-async def test_pin_tags_put_in_span(patch_grpc_aio, servicer, tracer):
+async def test_pin_tags_put_in_span(servicer, tracer):
     Pin.override(constants.GRPC_AIO_PIN_MODULE_SERVER, service="server1")
     Pin.override(constants.GRPC_AIO_PIN_MODULE_SERVER, tags={"tag1": "server"})
     target = f"localhost:{_GRPC_PORT}"

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections import namedtuple
+from concurrent import futures
 import sys
 
 import grpc
@@ -133,13 +134,15 @@ def patch_grpc_aio():
 @pytest.fixture
 def event_loop():
     loop = asyncio.new_event_loop()
+    executor = futures.ThreadPoolExecutor()
+    loop.set_default_executor(executor)
     yield loop
     to_cancel = asyncio.tasks.all_tasks(loop)
     for t in to_cancel:
         t.cancel()
     loop.run_until_complete(asyncio.tasks.gather(*to_cancel, return_exceptions=True))
     loop.run_until_complete(loop.shutdown_asyncgens())
-    loop.run_until_complete(loop.shutdown_default_executor())
+    executor.shutdown(wait=True)
     asyncio.events.set_event_loop(None)
     loop.close()
 

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -1,6 +1,5 @@
 import asyncio
 from collections import namedtuple
-from concurrent import futures
 import sys
 
 import grpc
@@ -130,22 +129,6 @@ def patch_grpc_aio():
     patch()
     yield
     unpatch()
-
-
-@pytest.fixture(autouse=True)
-def event_loop():
-    loop = asyncio.new_event_loop()
-    executor = futures.ThreadPoolExecutor()
-    loop.set_default_executor(executor)
-    yield loop
-    to_cancel = asyncio.tasks.all_tasks(loop)
-    for t in to_cancel:
-        t.cancel()
-    loop.run_until_complete(asyncio.tasks.gather(*to_cancel, return_exceptions=True))
-    loop.run_until_complete(loop.shutdown_asyncgens())
-    executor.shutdown(wait=True)
-    asyncio.events.set_event_loop(None)
-    loop.close()
 
 
 @pytest.fixture

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -5,6 +5,7 @@ import sys
 
 import grpc
 from grpc import aio
+import packaging.version
 import pytest
 import pytest_asyncio
 
@@ -472,8 +473,13 @@ async def test_unary_exception(servicer, tracer):
     assert server_span.resource == "/helloworld.Hello/SayHello"
     if servicer.abort_supported:
         assert server_span.error == 1
-        assert server_span.get_tag(ERROR_MSG) == "abort_details"
-        assert server_span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+        # grpc provide servicer_context.details and servicer_context.code above 1.38.0-pre1
+        if packaging.version.parse(grpc.__version__) >= packaging.version.parse("1.38.0-pre1"):
+            assert server_span.get_tag(ERROR_MSG) == "abort_details"
+            assert server_span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+        else:
+            assert server_span.get_tag(ERROR_MSG) == "Locally aborted."
+            assert "AbortError" in server_span.get_tag(ERROR_TYPE)
         assert server_span.get_tag(ERROR_MSG) in server_span.get_tag(ERROR_STACK)
         assert server_span.get_tag(ERROR_TYPE) in server_span.get_tag(ERROR_STACK)
 
@@ -548,8 +554,13 @@ async def test_server_streaming_exception(servicer, tracer):
     assert server_span.resource == "/helloworld.Hello/SayHelloTwice"
     if servicer.abort_supported:
         assert server_span.error == 1
-        assert server_span.get_tag(ERROR_MSG) == "abort_details"
-        assert server_span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+        # grpc provide servicer_context.details and servicer_context.code above 1.38.0-pre1
+        if packaging.version.parse(grpc.__version__) >= packaging.version.parse("1.38.0-pre1"):
+            assert server_span.get_tag(ERROR_MSG) == "abort_details"
+            assert server_span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+        else:
+            assert server_span.get_tag(ERROR_MSG) == "Locally aborted."
+            assert "AbortError" in server_span.get_tag(ERROR_TYPE)
         assert server_span.get_tag(ERROR_MSG) in server_span.get_tag(ERROR_STACK)
         assert server_span.get_tag(ERROR_TYPE) in server_span.get_tag(ERROR_STACK)
 
@@ -680,8 +691,13 @@ async def test_client_streaming_exception(servicer, tracer):
     assert server_span.resource == "/helloworld.Hello/SayHelloLast"
     if servicer.abort_supported:
         assert server_span.error == 1
-        assert server_span.get_tag(ERROR_MSG) == "abort_details"
-        assert server_span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+        # grpc provide servicer_context.details and servicer_context.code above 1.38.0-pre1
+        if packaging.version.parse(grpc.__version__) >= packaging.version.parse("1.38.0-pre1"):
+            assert server_span.get_tag(ERROR_MSG) == "abort_details"
+            assert server_span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+        else:
+            assert server_span.get_tag(ERROR_MSG) == "Locally aborted."
+            assert "AbortError" in server_span.get_tag(ERROR_TYPE)
         assert server_span.get_tag(ERROR_MSG) in server_span.get_tag(ERROR_STACK)
         assert server_span.get_tag(ERROR_TYPE) in server_span.get_tag(ERROR_STACK)
 
@@ -786,8 +802,13 @@ async def test_bidi_streaming_exception(servicer, tracer):
     assert server_span.resource == "/helloworld.Hello/SayHelloRepeatedly"
     if servicer.abort_supported:
         assert server_span.error == 1
-        assert server_span.get_tag(ERROR_MSG) == "abort_details"
-        assert server_span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+        # grpc provide servicer_context.details and servicer_context.code above 1.38.0-pre1
+        if packaging.version.parse(grpc.__version__) >= packaging.version.parse("1.38.0-pre1"):
+            assert server_span.get_tag(ERROR_MSG) == "abort_details"
+            assert server_span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+        else:
+            assert server_span.get_tag(ERROR_MSG) == "Locally aborted."
+            assert "AbortError" in server_span.get_tag(ERROR_TYPE)
         assert server_span.get_tag(ERROR_MSG) in server_span.get_tag(ERROR_STACK)
         assert server_span.get_tag(ERROR_TYPE) in server_span.get_tag(ERROR_STACK)
 

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -132,7 +132,7 @@ def patch_grpc_aio():
     unpatch()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def event_loop():
     loop = asyncio.new_event_loop()
     executor = futures.ThreadPoolExecutor()

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -67,23 +67,6 @@ class _HelloServicer(HelloServicer):
         yield HelloReply(message="Good bye")
 
 
-# non-async client streaming RPCs are not implemented
-# because `async for` cannot be executed in non-async functions.
-class _NonAsyncHelloServicer(HelloServicer):
-    def SayHello(self, request, context):
-        if request.name == "exception":
-            # Cannot be awaited so cannot abort
-            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "exception")
-        return HelloReply(message="Hello {}".format(request.name))
-
-    def SayHelloTwice(self, request, context):
-        yield HelloReply(message="first response")
-        if request.name == "exception":
-            # Cannot be awaited so cannot abort
-            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "exception")
-        yield HelloReply(message="second response")
-
-
 @pytest.fixture
 def patch_grpc_aio():
     patch()
@@ -106,28 +89,17 @@ async def server_target(event_loop, patch_grpc_aio, tracer):
     tracer fixture is imported to make sure the tracer is pinned to the modules.
     """
     target = f"localhost:{_GRPC_PORT}"
-    _server = _create_server(target, _HelloServicer())
+    _server = _create_server(target)
     await _server.start()
     yield target
     await _server.stop(grace=None)
     await _server.wait_for_termination()
 
 
-@pytest_asyncio.fixture
-async def non_async_server_target(event_loop, patch_grpc_aio, tracer):
-    """tracer fixture is imported to make sure the tracer is pinned to the modules."""
-    target = f"localhost:{_GRPC_PORT}"
-    _server = _create_server(target, _NonAsyncHelloServicer())
-    await _server.start()
-    yield target
-    await _server.stop(grace=None)
-    await _server.wait_for_termination()
-
-
-def _create_server(target, servicer):
+def _create_server(target):
     _server = aio.server()
     _server.add_insecure_port(target)
-    add_HelloServicer_to_server(servicer, _server)
+    add_HelloServicer_to_server(_HelloServicer(), _server)
     return _server
 
 
@@ -226,7 +198,7 @@ async def test_pin_tags_put_in_span(patch_grpc_aio, tracer):
     Pin.override(constants.GRPC_AIO_PIN_MODULE_SERVER, service="server1")
     Pin.override(constants.GRPC_AIO_PIN_MODULE_SERVER, tags={"tag1": "server"})
     target = f"localhost:{_GRPC_PORT}"
-    _server = _create_server(target, _HelloServicer())
+    _server = _create_server(target)
     await _server.start()
 
     Pin.override(constants.GRPC_AIO_PIN_MODULE_CLIENT, tags={"tag2": "client"})
@@ -384,37 +356,6 @@ async def test_unary_cancellation(server_target, tracer):
 
 
 @pytest.mark.asyncio
-async def test_unary_non_async_rpc(non_async_server_target, tracer):
-    async with aio.insecure_channel(non_async_server_target) as channel:
-        stub = HelloStub(channel)
-        response = await stub.SayHello(HelloRequest(name="test"))
-        assert response.message == "Hello test"
-
-    spans = tracer.writer.spans
-    assert len(spans) == 2
-    client_span, server_span = spans
-
-    _check_client_span(client_span, "grpc-aio-client", "SayHello", "unary")
-    _check_server_span(server_span, "grpc-aio-server", "SayHello", "unary")
-
-
-@pytest.mark.asyncio
-async def test_unary_non_async_rpc_exception(non_async_server_target, tracer):
-    async with aio.insecure_channel(non_async_server_target) as channel:
-        stub = HelloStub(channel)
-        response = await stub.SayHello(HelloRequest(name="exception"))
-        assert response.message == "Hello exception"
-
-    spans = tracer.writer.spans
-    assert len(spans) == 2
-    client_span, server_span = spans
-
-    _check_client_span(client_span, "grpc-aio-client", "SayHello", "unary")
-    # abort call doesn't take effect
-    _check_server_span(server_span, "grpc-aio-server", "SayHello", "unary")
-
-
-@pytest.mark.asyncio
 async def test_server_streaming(server_target, tracer):
     async with aio.insecure_channel(server_target) as channel:
         stub = HelloStub(channel)
@@ -520,49 +461,6 @@ async def test_server_streaming_cancelled_after_rpc(server_target, tracer):
 
     # No error because cancelled after execution
     _check_client_span(client_span, "grpc-aio-client", "SayHelloTwice", "server_streaming")
-    _check_server_span(server_span, "grpc-aio-server", "SayHelloTwice", "server_streaming")
-
-
-@pytest.mark.asyncio
-async def test_server_streaming_non_async_rpc(non_async_server_target, tracer):
-    async with aio.insecure_channel(non_async_server_target) as channel:
-        stub = HelloStub(channel)
-        response_counts = 0
-        async for response in stub.SayHelloTwice(HelloRequest(name="test")):
-            if response_counts == 0:
-                assert response.message == "first response"
-            elif response_counts == 1:
-                assert response.message == "second response"
-            response_counts += 1
-        assert response_counts == 2
-
-    spans = tracer.writer.spans
-    assert len(spans) == 2
-    client_span, server_span = spans
-
-    _check_client_span(client_span, "grpc-aio-client", "SayHelloTwice", "server_streaming")
-    _check_server_span(server_span, "grpc-aio-server", "SayHelloTwice", "server_streaming")
-
-
-@pytest.mark.asyncio
-async def test_server_streaming_non_async_rpc_exception(non_async_server_target, tracer):
-    async with aio.insecure_channel(non_async_server_target) as channel:
-        stub = HelloStub(channel)
-        response_counts = 0
-        async for response in stub.SayHelloTwice(HelloRequest(name="exception")):
-            if response_counts == 0:
-                assert response.message == "first response"
-            elif response_counts == 1:
-                assert response.message == "second response"
-            response_counts += 1
-        assert response_counts == 2
-
-    spans = tracer.writer.spans
-    assert len(spans) == 2
-    client_span, server_span = spans
-
-    _check_client_span(client_span, "grpc-aio-client", "SayHelloTwice", "server_streaming")
-    # abort call doesn't take effect
     _check_server_span(server_span, "grpc-aio-server", "SayHelloTwice", "server_streaming")
 
 

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -855,6 +855,7 @@ async def test_bidi_streaming_cancelled_during_rpc(servicer, tracer):
                 # here it waits for the server-side RPC to be done.
                 await asyncio.sleep(0.5)
 
+    await asyncio.sleep(0.5)  # wait for executor pool of AioServer to handle exception
     spans = tracer.writer.spans
     assert len(spans) == 2
     client_span, server_span = spans


### PR DESCRIPTION
As I described [here](https://github.com/ysk24ok/dd-trace-py/pull/1#issuecomment-1044596806). You should not wrap sync handler within async interceptor.

- Create `_TracedRpcMethodHandler` in `aio_server_interceptor.py`
- Extract `_create_span` from `_TracedAioRpcMethodHandler` to share with `_TracedRpcMethodHandler`
- Rename `_wrap_*_response` to `_wrap_aio_*_response` and create sync versions
- Create `_handle_server_exception`
  - I found that `servicer_context` contains `details` and `code` for aborted request
  - Available above 1.38.0-pre1. https://github.com/grpc/grpc/pull/26143
- Assert that methods of `_SyncHelloServicer` are not invoked in async context on unit test
- Fixes some type annotations